### PR TITLE
feat: add clearSoldOutWishlist mutation

### DIFF
--- a/app/wishlist/mutations/clearSoldOutWishlist.ts
+++ b/app/wishlist/mutations/clearSoldOutWishlist.ts
@@ -1,0 +1,37 @@
+import { AuthorizationError, Ctx, resolver } from 'blitz'
+import db from 'db'
+
+import getWishlist from 'app/wishlist/queries/getWishlist'
+
+/**
+ * Clears the sold out items from the wishlist, and returns the updated wishlist
+ */
+export default resolver.pipe(
+  resolver.authorize(),
+  async (_ = null, { session }: Ctx) => {
+    if (!session.userId) throw new AuthorizationError()
+    const wishlist = await getWishlist(null, { session })
+
+    const soldProducts = wishlist
+      .filter((product) => product.soldPrice !== null)
+      .map((product) => ({
+        id: product.id,
+      }))
+
+    const user = await db.user.update({
+      where: {
+        id: session.userId,
+      },
+      data: {
+        wishlist: {
+          disconnect: soldProducts,
+        },
+      },
+      include: {
+        wishlist: true,
+      },
+    })
+
+    return user.wishlist
+  }
+)


### PR DESCRIPTION
add clear all sold out products from wishlist mutation

Currently, i have no idea how to do it in one query, since the `disconnect` query only allows unique fields so i can't do something like "disconnect all products with soldPrice !== null", so I have to use 2 separate queries for now.