### PR TITLE
fix: api docs publish

### DIFF
--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -31,9 +31,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install Surge
-        run: yarn global add surge
-
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
@@ -45,8 +42,8 @@ jobs:
 
       - name: Publish production documentation
         if: github.ref == 'refs/heads/master'
-        run: surge ./api-docs --domain https://mayday-api.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: yarn dlx surge ./api-docs --domain https://mayday-api.surge.sh --token ${{ secrets.SURGE_TOKEN }}
 
       - name: Publish dev documentation
         if: github.ref == 'refs/heads/dev'
-        run: surge ./api-docs --domain https://mayday-api-dev.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: yarn dlx surge ./api-docs --domain https://mayday-api-dev.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
`yarn global` was removed in v2.x

switching to `yarn dlx` instead